### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module endext
+module github.com/SirBugs/endext
 
 go 1.19


### PR DESCRIPTION
changed the module path
so it is possible to install the package using 
`go install github.com/SirBugs/endext@<version>`

### you need just to create a tag with version in github 